### PR TITLE
python 3.10

### DIFF
--- a/warc/utils.py
+++ b/warc/utils.py
@@ -7,7 +7,7 @@ This file is part of warc
 :copyright: (c) 2012 Internet Archive
 """
 
-from collections import MutableMapping, Mapping
+from collections.abc import MutableMapping, Mapping
 from http.client import HTTPMessage
 import email.parser
 import sys


### PR DESCRIPTION
MutableMapping and Mapping were moved from `collections` to `collections.abc`