### PR TITLE
collections -> collections.abc for Mapping and MutableMapping.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="warc3-wet",
-    version="0.2.3",
+    version="0.2.4",
     description="Python library to work with ARC and WARC files",
     long_description=open('Readme.rst').read(),
     license='GPLv2',

--- a/warc/utils.py
+++ b/warc/utils.py
@@ -7,7 +7,7 @@ This file is part of warc
 :copyright: (c) 2012 Internet Archive
 """
 
-from collections import MutableMapping, Mapping
+from collections.abc import MutableMapping, Mapping
 from http.client import HTTPMessage
 import email.parser
 import sys


### PR DESCRIPTION
In Python 3, `Mapping` and `MutableMapping` are in `collections.abc`, not `collections`.